### PR TITLE
Correcting invocation example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ configure swaddle vendor 'someone else'
 Of course, using this couldn't be easier:-
 
 ```bash
-swaddle --swaddling-path /path/to/swaddling /path/to/output -- overdrive
+swaddle --swaddling-path /path/to/swaddling --output-path /path/to/output -- overdrive
 ```
 
 And off we go!


### PR DESCRIPTION
Correcting invocation example. I lost quite some time chasing ghosts, meanwhile overlooking I forgot to put the "--output-path" argument in front of the output folder. Hopefully, this prevents others wasting time. :-)