### PR TITLE
Fixing the test for empty arrays.

### DIFF
--- a/lib/shellfire/swaddle/build/package/deb.functions
+++ b/lib/shellfire/swaddle/build/package/deb.functions
@@ -499,7 +499,7 @@ _swaddle_build_package_deb_commaSeparatedControlField()
 	local configurationSettingValue
 	_configure_configurationSettingValue "$namespace" "$configurationSettingName"
 	
-	if ! core_variable_array_isEmpty "$configurationSettingValue"; then
+	if core_variable_array_isEmpty "$configurationSettingValue"; then
 		return
 	fi
 	


### PR DESCRIPTION
The test for empty arrays was incorrect. For example: your own swaddle deb package doesn't have the deb package dependencies in the resulting control file. When installing swaddle, none of the archiving tools are installed with it.

Can you merge and possibly create a new release? Don't forget to create a local fixed swaddle script first so you can use that one to create the packages for the dependencies to be correct. :-)